### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Redis connector
 og:title: Set up a Redis connector - C1 docs
-og:description: Integrate your Redis instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Redis. Integrate your Redis instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Redis. Integrate your Redis instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Redis. Integrate your Redis instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Redis
 ---
 
@@ -23,7 +23,7 @@ To set up the integration with C1, you'll need:
 
 - The username and password for a Redis user (or service account) with admin permissions
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Redis connector
 
@@ -81,7 +81,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Redis connector is now pulling access data into C1.
+**Done.** Your Redis connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Redis connector, hosted and run in your own environment.**
@@ -198,7 +198,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Redis connector is now pulling access data into C1.
+**Done.** Your Redis connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines