### PR TITLE
fix: lock for write in GetRoles cache-fill path

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -152,8 +152,8 @@ func (o *roleBuilder) GetUsers(ctx context.Context) error {
 }
 
 func (o *roleBuilder) GetRoles(ctx context.Context) error {
-	o.rolesMutex.RLock()
-	defer o.rolesMutex.RUnlock()
+	o.rolesMutex.Lock()
+	defer o.rolesMutex.Unlock()
 
 	if o.roles == nil {
 		o.roles = make(map[int]client.Role)

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -133,8 +133,8 @@ func newRoleBuilder(c *client.RedisClient) *roleBuilder {
 }
 
 func (o *roleBuilder) GetUsers(ctx context.Context) error {
-	o.usersMutex.RLock()
-	defer o.usersMutex.RUnlock()
+	o.usersMutex.Lock()
+	defer o.usersMutex.Unlock()
 
 	if o.users != nil || len(o.users) > 0 {
 		return nil


### PR DESCRIPTION
\`roleBuilder.GetRoles\` acquired \`RLock\` on \`rolesMutex\`, then -- on the cache-miss path -- wrote to the shared \`o.roles\` map (initialising the nil map and storing the per-UID role). \`RLock\` permits multiple readers AND multiple \`RLock\` holders, so the assignments raced against any concurrent \`GetRoles\` call. The runtime would either silently corrupt the map header or panic with \`concurrent map read and write\` / \`concurrent map writes\` once the windows lined up under load.

Switched to the write \`Lock\`/\`Unlock\`. The contention is bounded by single cache-miss invocations for the lifetime of the builder, so the additional serialisation is negligible.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`map_write_under_rlock\`.