### PR TITLE
fix: mark password as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 		"password",
 		field.WithDescription("The enterprise cluster admin password"),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	),
 })
 


### PR DESCRIPTION
Marks the Redis Enterprise cluster admin `password` config field as secret. baton-redis defines config in Go with no committed config_schema.json, so the fix adds `field.WithIsSecret(true)` (the schema-generation source of truth).

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

Review only — do not merge.
