### PR TITLE
CXH-1894: update connector - on prem only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 BUILD_DIR = dist/${GOOS}_${GOARCH}
-GENERATED_CONF = pkg/config/conf.gen.go
+GENERATED_CONF := pkg/config/conf.gen.go
 
 ifeq ($(GOOS),windows)
 OUTPUT_PATH = ${BUILD_DIR}/baton-redis.exe
@@ -9,16 +9,22 @@ else
 OUTPUT_PATH = ${BUILD_DIR}/baton-redis
 endif
 
+# Set the build tag conditionally based on BATON_LAMBDA_SUPPORT
+ifdef BATON_LAMBDA_SUPPORT
+	BUILD_TAGS=-tags baton_lambda_support
+else
+	BUILD_TAGS=
+endif
+
 .PHONY: build
 build: $(GENERATED_CONF)
-	go build -o ${OUTPUT_PATH} ./cmd/baton-redis
+	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-redis
 
 $(GENERATED_CONF): pkg/config/config.go go.mod
+	@echo "Generating $(GENERATED_CONF)..."
 	go generate ./pkg/config
 
-.PHONY: generate
-generate:
-	go generate ./pkg/config
+generate: $(GENERATED_CONF)
 
 .PHONY: update-deps
 update-deps:

--- a/cmd/baton-redis/main.go
+++ b/cmd/baton-redis/main.go
@@ -2,67 +2,19 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
-	"github.com/conductorone/baton-redis/pkg/client"
 	cfg "github.com/conductorone/baton-redis/pkg/config"
-	connectorSchema "github.com/conductorone/baton-redis/pkg/connector"
+	"github.com/conductorone/baton-redis/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 var version = "dev"
 
 func main() {
 	ctx := context.Background()
-
-	_, cmd, err := config.DefineConfiguration(
-		ctx,
-		"baton-redis",
-		getConnector,
-		cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connectorSchema.Connector{}),
+	config.RunConnector(ctx, "baton-redis", version, cfg.Config,
+		connector.NewLambdaConnector,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func getConnector(ctx context.Context, rc *cfg.Redis) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-
-	if err := cfg.ValidateConfig(rc); err != nil {
-		return nil, err
-	}
-
-	redisClient := client.NewClient(rc.Username, rc.Password, rc.ClusterHost, rc.ApiPort)
-
-	connectorBuilder, err := connectorSchema.New(ctx, redisClient)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	opts := make([]connectorbuilder.Opt, 0)
-
-	connector, err := connectorbuilder.NewConnector(ctx, connectorBuilder, opts...)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-	return connector, nil
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -94,7 +94,9 @@
     },
     {
       "name": "cluster-host",
+      "displayName": "Cluster Host",
       "description": "The enterprise cluster host",
+      "placeholder": "Your Redis Enterprise cluster host",
       "isRequired": true,
       "stringField": {
         "rules": {
@@ -104,14 +106,18 @@
     },
     {
       "name": "api-port",
+      "displayName": "API Port",
       "description": "The enterprise API port",
+      "placeholder": "9443",
       "stringField": {
         "defaultValue": "9443"
       }
     },
     {
       "name": "username",
+      "displayName": "Username",
       "description": "The enterprise cluster admin username",
+      "placeholder": "Your Redis Enterprise admin username",
       "isRequired": true,
       "stringField": {
         "rules": {
@@ -121,7 +127,9 @@
     },
     {
       "name": "password",
+      "displayName": "Password",
       "description": "The enterprise cluster admin password",
+      "placeholder": "Your Redis Enterprise admin password",
       "isRequired": true,
       "isSecret": true,
       "stringField": {
@@ -130,5 +138,8 @@
         }
       }
     }
-  ]
+  ],
+  "displayName": "Redis",
+  "helpUrl": "/docs/baton/redis",
+  "iconUrl": "/static/app-icons/redis.svg"
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -66,10 +66,10 @@ Click **Next**.
 Find the **Settings** area of the page and click **Edit**.
 </Step>
 <Step>
-In the **Cluster host** field, enter your Redis Enterprise Service cluster host. 
+In the **Cluster Host** field, enter your Redis Enterprise Service cluster host. 
 </Step>
 <Step>
-In the **API port** field, enter the enterprise API port (defaults to `9443`).
+In the **API Port** field, enter the enterprise API port (defaults to `9443`).
 </Step>
 <Step>
 In the **Username** and **Password** fields, enter the login credentials for a Redis user with admin permissions. 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,29 +6,49 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
-var Config = field.NewConfiguration([]field.SchemaField{
-	field.StringField(
+var (
+	clusterHostField = field.StringField(
 		"cluster-host",
 		field.WithDescription("The enterprise cluster host"),
+		field.WithDisplayName("Cluster Host"),
+		field.WithPlaceholder("Your Redis Enterprise cluster host"),
 		field.WithRequired(true),
-	),
-	field.StringField(
+	)
+	apiPortField = field.StringField(
 		"api-port",
 		field.WithDescription("The enterprise API port"),
+		field.WithDisplayName("API Port"),
+		field.WithPlaceholder("9443"),
 		field.WithDefaultValue("9443"),
-	),
-	field.StringField(
+	)
+	usernameField = field.StringField(
 		"username",
 		field.WithDescription("The enterprise cluster admin username"),
+		field.WithDisplayName("Username"),
+		field.WithPlaceholder("Your Redis Enterprise admin username"),
 		field.WithRequired(true),
-	),
-	field.StringField(
+	)
+	passwordField = field.StringField(
 		"password",
 		field.WithDescription("The enterprise cluster admin password"),
+		field.WithDisplayName("Password"),
+		field.WithPlaceholder("Your Redis Enterprise admin password"),
 		field.WithRequired(true),
 		field.WithIsSecret(true),
-	),
-})
+	)
+)
+
+var Config = field.NewConfiguration(
+	[]field.SchemaField{
+		clusterHostField,
+		apiPortField,
+		usernameField,
+		passwordField,
+	},
+	field.WithConnectorDisplayName("Redis"),
+	field.WithIconUrl("/static/app-icons/redis.svg"),
+	field.WithHelpUrl("/docs/baton/redis"),
+)
 
 func ValidateConfig(c *Redis) error {
 	return nil

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"io"
 
+	cfg "github.com/conductorone/baton-redis/pkg/config"
 	"github.com/conductorone/baton-redis/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -16,9 +18,9 @@ type Connector struct {
 	client *client.RedisClient
 }
 
-// ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
-func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+// ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
+func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		newUserBuilder(d.client),
 		newRoleBuilder(d.client),
 	}
@@ -57,4 +59,14 @@ func New(ctx context.Context, redisClient *client.RedisClient) (*Connector, erro
 	return &Connector{
 		client: redisClient,
 	}, nil
+}
+
+// NewLambdaConnector satisfies cli.NewConnector for use with config.RunConnector.
+func NewLambdaConnector(ctx context.Context, ac *cfg.Redis, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	redisClient := client.NewClient(ac.Username, ac.Password, ac.ClusterHost, ac.ApiPort)
+	cb, err := New(ctx, redisClient)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cb, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"io"
 
-	cfg "github.com/conductorone/baton-redis/pkg/config"
 	"github.com/conductorone/baton-redis/pkg/client"
+	cfg "github.com/conductorone/baton-redis/pkg/config"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/cli"

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -8,11 +8,9 @@ import (
 
 	"github.com/conductorone/baton-redis/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
-	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type roleBuilder struct {
@@ -28,25 +26,25 @@ func (o *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return roleResourceType
 }
 
-func (o *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var resources []*v2.Resource
 
 	// Note: Redis Enterprise Service API doesn't support pagination.
-	roles, annotation, err := o.client.ListRoles(ctx)
+	roles, _, err := o.client.ListRoles(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, role := range roles {
 		roleCopy := role
 		roleResource, err := parseIntoRoleResource(ctx, &roleCopy, nil)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, roleResource)
 	}
 
-	return resources, "", annotation, nil
+	return resources, nil, nil
 }
 
 func parseIntoRoleResource(_ context.Context, role *client.Role, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -56,18 +54,18 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, parentResourceI
 		"management_role": role.Management,
 	}
 
-	roleTraits := []resource.RoleTraitOption{
-		resource.WithRoleProfile(profile),
+	roleTraits := []rs.RoleTraitOption{
+		rs.WithRoleProfile(profile),
 	}
 
 	displayName := role.Name
 
-	ret, err := resource.NewRoleResource(
+	ret, err := rs.NewRoleResource(
 		displayName,
 		roleResourceType,
 		role.UID,
 		roleTraits,
-		resource.WithParentResourceID(parentResourceID),
+		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
 		return nil, err
@@ -76,12 +74,12 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, parentResourceI
 	return ret, nil
 }
 
-func (o *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var entitlements []*v2.Entitlement
 	role, _, err := o.client.GetRoleDetails(ctx, resource.Id.Resource)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	assigmentOptions := []entitlement.EntitlementOption{
@@ -92,20 +90,20 @@ func (o *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _
 
 	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, role.Management, assigmentOptions...))
 
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
-func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var grants []*v2.Grant
 
 	// Note: Redis Enterprise Service API doesn't support pagination.
 	err := o.GetUsers(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 	err = o.GetRoles(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, user := range o.users {
@@ -122,7 +120,7 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagi
 		}
 	}
 
-	return grants, "", nil, nil
+	return grants, nil, nil
 }
 
 func newRoleBuilder(c *client.RedisClient) *roleBuilder {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/conductorone/baton-redis/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -30,7 +31,7 @@ func (o *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAtt
 	var resources []*v2.Resource
 
 	// Note: Redis Enterprise Service API doesn't support pagination.
-	roles, _, err := o.client.ListRoles(ctx)
+	roles, annos, err := o.client.ListRoles(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -44,7 +45,7 @@ func (o *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAtt
 		resources = append(resources, roleResource)
 	}
 
-	return resources, nil, nil
+	return resources, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func parseIntoRoleResource(_ context.Context, role *client.Role, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -97,14 +98,15 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 	var grants []*v2.Grant
 
 	// Note: Redis Enterprise Service API doesn't support pagination.
-	err := o.GetUsers(ctx)
+	userAnnos, err := o.GetUsers(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-	err = o.GetRoles(ctx)
+	roleAnnos, err := o.GetRoles(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	annos := append(userAnnos, roleAnnos...)
 
 	for _, user := range o.users {
 		for _, roleUID := range user.RoleUIDs {
@@ -120,7 +122,7 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 		}
 	}
 
-	return grants, nil, nil
+	return grants, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func newRoleBuilder(c *client.RedisClient) *roleBuilder {
@@ -130,26 +132,25 @@ func newRoleBuilder(c *client.RedisClient) *roleBuilder {
 	}
 }
 
-func (o *roleBuilder) GetUsers(ctx context.Context) error {
+func (o *roleBuilder) GetUsers(ctx context.Context) (annotations.Annotations, error) {
 	o.usersMutex.Lock()
 	defer o.usersMutex.Unlock()
 
 	if o.users != nil || len(o.users) > 0 {
-		return nil
+		return nil, nil
 	}
 
-	users, _, err := o.client.ListUsers(ctx)
-
+	users, annos, err := o.client.ListUsers(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	o.users = users
 
-	return nil
+	return annos, nil
 }
 
-func (o *roleBuilder) GetRoles(ctx context.Context) error {
+func (o *roleBuilder) GetRoles(ctx context.Context) (annotations.Annotations, error) {
 	o.rolesMutex.Lock()
 	defer o.rolesMutex.Unlock()
 
@@ -158,18 +159,17 @@ func (o *roleBuilder) GetRoles(ctx context.Context) error {
 	}
 
 	if len(o.roles) > 0 {
-		return nil
+		return nil, nil
 	}
 
-	roles, _, err := o.client.ListRoles(ctx)
-
+	roles, annos, err := o.client.ListRoles(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, role := range roles {
 		o.roles[role.UID] = role
 	}
 
-	return nil
+	return annos, nil
 }

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -77,7 +77,7 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, parentResourceI
 
 func (o *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var entitlements []*v2.Entitlement
-	role, _, err := o.client.GetRoleDetails(ctx, resource.Id.Resource)
+	role, annos, err := o.client.GetRoleDetails(ctx, resource.Id.Resource)
 
 	if err != nil {
 		return nil, nil, err
@@ -91,7 +91,7 @@ func (o *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _
 
 	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, role.Management, assigmentOptions...))
 
-	return entitlements, nil, nil
+	return entitlements, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
@@ -106,7 +106,7 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 	if err != nil {
 		return nil, nil, err
 	}
-	annos := append(userAnnos, roleAnnos...)
+	userAnnos = append(userAnnos, roleAnnos...)
 
 	for _, user := range o.users {
 		for _, roleUID := range user.RoleUIDs {
@@ -122,7 +122,7 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.Sy
 		}
 	}
 
-	return grants, &rs.SyncOpResults{Annotations: annos}, nil
+	return grants, &rs.SyncOpResults{Annotations: userAnnos}, nil
 }
 
 func newRoleBuilder(c *client.RedisClient) *roleBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -25,7 +25,7 @@ func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAtt
 	var resources []*v2.Resource
 
 	// Note: Redis Enterprise Service API doesn't support pagination.
-	users, _, err := o.client.ListUsers(ctx)
+	users, annos, err := o.client.ListUsers(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +39,7 @@ func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAtt
 		resources = append(resources, userResource)
 	}
 
-	return resources, nil, nil
+	return resources, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func parseIntoUserResource(_ context.Context, user *client.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/conductorone/baton-redis/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
-	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type userBuilder struct {
@@ -23,25 +21,25 @@ func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
-func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var resources []*v2.Resource
 
 	// Note: Redis Enterprise Service API doesn't support pagination.
-	users, annotation, err := o.client.ListUsers(ctx)
+	users, _, err := o.client.ListUsers(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, user := range users {
 		userCopy := user
 		userResource, err := parseIntoUserResource(ctx, &userCopy, nil)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, userResource)
 	}
 
-	return resources, "", annotation, nil
+	return resources, nil, nil
 }
 
 func parseIntoUserResource(_ context.Context, user *client.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -55,20 +53,20 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 		"role_uids":       parseRoleUIDs(user.RoleUIDs),
 	}
 
-	userTraits := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(userStatus),
-		resource.WithUserLogin(user.Name),
+	userTraits := []rs.UserTraitOption{
+		rs.WithUserProfile(profile),
+		rs.WithStatus(userStatus),
+		rs.WithUserLogin(user.Name),
 	}
 
 	displayName := user.Name
 
-	ret, err := resource.NewUserResource(
+	ret, err := rs.NewUserResource(
 		displayName,
 		userResourceType,
 		user.UID,
 		userTraits,
-		resource.WithParentResourceID(parentResourceID),
+		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
 		return nil, err
@@ -78,13 +76,13 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 }
 
 // Entitlements always returns an empty slice for users.
-func (o *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (o *userBuilder) Grants(ctx context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *userBuilder) Grants(ctx context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(c *client.RedisClient) *userBuilder {


### PR DESCRIPTION
Containerizes baton-redis per the containerization guide.
Changes: ConnectorBuilderV2/ResourceSyncerV2 migration, config.go metadata, gen/gen.go, Makefile BATON_LAMBDA_SUPPORT, main.go RunConnector, CI cleanup.
Linear: CXH-1894